### PR TITLE
Update company auth user creation

### DIFF
--- a/src/hooks/auth/authUtils.ts
+++ b/src/hooks/auth/authUtils.ts
@@ -42,11 +42,12 @@ export const updateUserMetadata = async (metadata: Record<string, any>) => {
   });
 };
 
-export const createCompanyAuthUser = async (email: string, companyId: string) => {
-  return await supabase.functions.invoke(
-    'create-company-auth-user',
-    {
-      body: { email, companyId }
-    }
-  );
+export const createCompanyAuthUser = async (
+  email: string,
+  companyId: string,
+  password?: string
+) => {
+  return await supabase.functions.invoke('create-company-auth-user', {
+    body: { email, companyId, password }
+  });
 };

--- a/src/hooks/auth/companySignInService.ts
+++ b/src/hooks/auth/companySignInService.ts
@@ -24,7 +24,11 @@ export const createCompanySignInService = (toast: any) => {
         if (companies && companies.length > 0) {
           const company = companies[0];
           console.log(`[CompanySignIn] Company ${company.name} found. Attempting to create/link auth user.`);
-          const { data: createResult, error: createError } = await createCompanyAuthUser(email, company.id);
+          const { data: createResult, error: createError } = await createCompanyAuthUser(
+            email,
+            company.id,
+            password
+          );
 
           if (createError || !createResult?.success) {
             console.error(`[CompanySignIn] Failed to create/link auth user for company ${company.id}. Error: ${createError?.message}`);

--- a/supabase/functions/create-company-auth-user/index.ts
+++ b/supabase/functions/create-company-auth-user/index.ts
@@ -22,8 +22,8 @@ serve(async (req) => {
     return new Response(JSON.stringify({ error: 'Invalid JSON body' }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
   }
 
-  const { email, companyId, companyName, contactName } = requestBody; // contactName is available but not used in current logic.
-  console.log('[create-company-auth-user] Request body parsed:', { email, companyId, companyName, contactName });
+  const { email, companyId, companyName, contactName, password } = requestBody; // contactName is available but not used in current logic.
+  console.log('[create-company-auth-user] Request body parsed:', { email, companyId, companyName, contactName, hasPassword: !!password });
 
   if (!email || !companyId) {
     console.error('[create-company-auth-user] Missing required parameters: email or companyId.');
@@ -96,7 +96,10 @@ serve(async (req) => {
         console.log('[create-company-auth-user] Successfully updated metadata for existing auth user.');
       }
     } else {
-      const tempPassword = Deno.env.get('NEW_COMPANY_USER_DEFAULT_PASSWORD') || 'ia360graus';
+      const tempPassword =
+        password ||
+        Deno.env.get('NEW_COMPANY_USER_DEFAULT_PASSWORD') ||
+        'ia360graus';
       console.log(`[create-company-auth-user] No existing auth user. Creating new one for email: ${email}`);
       const { data: newAuthUserData, error: createAuthError } = await supabaseAdmin.auth.admin.createUser({
         email: email,


### PR DESCRIPTION
## Summary
- support providing password in createCompanyAuthUser
- use same password in company sign in service
- allow Edge function to accept optional password when creating user

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dc4834ee8832db8dd657b63bd61f7