### PR TITLE
Improve resend invite button status handling

### DIFF
--- a/src/components/company/CompanyCollaboratorsList.tsx
+++ b/src/components/company/CompanyCollaboratorsList.tsx
@@ -2,6 +2,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
+import { useState } from "react";
 import { 
   UserCog, 
   UserX, 
@@ -32,6 +33,7 @@ export function CompanyCollaboratorsList({
 }: CompanyCollaboratorsListProps) {
   const toggleStatusMutation = useToggleCollaboratorStatus();
   const resendInvitationMutation = useResendInvitation();
+  const [sendingId, setSendingId] = useState<string | null>(null);
 
   const handleToggleStatus = async (collaborator: Collaborator) => {
     await toggleStatusMutation.mutateAsync({
@@ -42,10 +44,15 @@ export function CompanyCollaboratorsList({
   };
 
   const handleResendInvitation = async (collaborator: Collaborator) => {
-    await resendInvitationMutation.mutateAsync({
-      collaborator_id: collaborator.id,
-      company_id: companyId
-    });
+    setSendingId(collaborator.id);
+    try {
+      await resendInvitationMutation.mutateAsync({
+        collaborator_id: collaborator.id,
+        company_id: companyId
+      });
+    } finally {
+      setSendingId(null);
+    }
   };
 
   const formatDate = (dateString: string) => {
@@ -125,10 +132,14 @@ export function CompanyCollaboratorsList({
                     variant="outline"
                     size="sm"
                     onClick={() => handleResendInvitation(collaborator)}
-                    disabled={resendInvitationMutation.isPending}
+                    disabled={
+                      resendInvitationMutation.isPending &&
+                      sendingId === collaborator.id
+                    }
                     className="flex items-center gap-2"
                   >
-                    {resendInvitationMutation.isPending ? (
+                    {resendInvitationMutation.isPending &&
+                    sendingId === collaborator.id ? (
                       <Loader2 className="h-4 w-4 animate-spin" />
                     ) : (
                       <MailOpen className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- track which collaborator's invite is being resent
- show loader and disable button only for that collaborator

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6868989e0628832d90a302bf6b596670