### PR TITLE
Use env variables for Supabase client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example environment variables for development
+# Replace the values with your Supabase project credentials
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key

--- a/README.md
+++ b/README.md
@@ -48,7 +48,18 @@ npm run dev
 - Click on the "Code" button (green button) near the top right.
 - Select the "Codespaces" tab.
 - Click on "New codespace" to launch a new Codespace environment.
-- Edit files directly within the Codespace and commit and push your changes once you're done.
+ - Edit files directly within the Codespace and commit and push your changes once you're done.
+
+## Environment variables
+
+This project uses Supabase. Copy `.env.example` to `.env` and fill in your project credentials:
+
+```sh
+cp .env.example .env
+# then edit .env and set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY
+```
+
+Both development (`npm run dev`) and production builds (`npm run build`) read these values via `import.meta.env`.
 
 ## What technologies are used for this project?
 

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -3,8 +3,8 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://swmxqjdvungochdjvtjg.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN3bXhxamR2dW5nb2NoZGp2dGpnIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTAwOTMzOTYsImV4cCI6MjA2NTY2OTM5Nn0.RqmWdYj-_LCfRr2l6xYJIsCDhWUAUl2ho_-KrUp1igc";
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string;
+const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";


### PR DESCRIPTION
## Summary
- load Supabase credentials from `import.meta.env`
- add `.env.example` describing the `VITE_SUPABASE_*` variables
- document environment setup in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869cb2af78c832d93cbf3a6715c2c9d